### PR TITLE
Ability to override color for gunpods/radome/jammers

### DIFF
--- a/Assets/Scripts/Editor/LiveryBuilder.cs
+++ b/Assets/Scripts/Editor/LiveryBuilder.cs
@@ -37,7 +37,7 @@ public class LiveryBuilder : ModBuilder<LiveryData, LiveryMetaData>
         asset.Texture = Texture;
         asset.Glossiness = Glossiness;
         asset.Colors = TextureColorCalculator.GetPallet(Texture, 5)
-            .Select(x => new LiveryData.TextureColor { Color = x.color, Count = x.count })
+            .Select(x => new LiveryData.TextureColor { Color = UseCustomColor ? CustomColor : x.color, Count = x.count })
             .ToArray();
         return asset;
     }
@@ -51,6 +51,9 @@ public class LiveryBuilder : ModBuilder<LiveryData, LiveryMetaData>
             Aircraft = Aircraft,
         };
     }
+
+    public bool UseCustomColor = false;
+    public Color32 CustomColor;
 }
 
 internal static class TextureColorCalculator


### PR DESCRIPTION
I didn't wanna break anything, so my edit just overrides calculated colors with one custom one before storing in `LiveryData.TextureColor`. 

I am willing to rewrite this part of code better, but i need to understand why `asset.Colors` is an array instead of just one (most common) color. Like does it need to be array of 5? Or 1 is sufficient?